### PR TITLE
Support custom error

### DIFF
--- a/tasks/upload_selectors.js
+++ b/tasks/upload_selectors.js
@@ -28,7 +28,14 @@ task(
   }));
 
   const compositeAbi = Object.values(elements).filter(function (el) {
-    return el.type === 'function' || el.type === 'event';
+    return el.type === 'function' || el.type === 'event' || el.type === 'error';
+  });
+
+  compositeAbi.map(function (el) {
+    if (el.type === 'error') {
+      el.type = 'function';
+      el.outputs = []
+    }
   });
 
   if (compositeAbi.length === 0) {

--- a/tasks/upload_selectors.js
+++ b/tasks/upload_selectors.js
@@ -32,6 +32,7 @@ task(
   });
 
   compositeAbi.forEach(function (el) {
+    // We convert all errors to 'function' type, since 4byte.directory not support ABIs that include errors and both types are encoded in the same way.
     if (el.type === 'error') {
       el.type = 'function';
       el.outputs = []

--- a/tasks/upload_selectors.js
+++ b/tasks/upload_selectors.js
@@ -31,7 +31,7 @@ task(
     return el.type === 'function' || el.type === 'event' || el.type === 'error';
   });
 
-  compositeAbi.map(function (el) {
+  compositeAbi.forEach(function (el) {
     if (el.type === 'error') {
       el.type = 'function';
       el.outputs = []


### PR DESCRIPTION
Since v0.8.0, [Custom Error](https://docs.soliditylang.org/en/v0.8.19/structure-of-a-contract.html#errors)s are introduced. The custom error's signature is generated in the same way as regular method. This PR supports uploading these error into 4 byte directory.